### PR TITLE
Add `Look.NumRelations()`

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -303,12 +303,12 @@ func parseLine(data []byte, line, offset int64) (*parsed, error) {
 	for ; wordcount > 0; wordcount-- {
 		value, err := l.lexWord()
 		if err != nil {
-			return nil, fmt.Errorf("word expected: %s")
+			return nil, fmt.Errorf("word expected on line %d", line)
 		}
 		// XXX: handle syntactic markers
 		sense, err := l.lexHexNumber()
 		if err != nil {
-			return nil, fmt.Errorf("sense id expected: %s")
+			return nil, fmt.Errorf("sense id expected on line %d", line)
 		}
 		p.words = append(p.words, word{
 			word:  value,

--- a/wordnet.go
+++ b/wordnet.go
@@ -184,6 +184,10 @@ func (w *Lookup) Synonyms() (synonyms []string) {
 	return synonyms
 }
 
+func (w *Lookup) NumRelations() int {
+	return len(w.cluster.relations)
+}
+
 // Get words related to this word.  r is a bitfield of relation types
 // to include
 func (w *Lookup) Related(r Relation) (relationships []Lookup) {

--- a/wordnet.go
+++ b/wordnet.go
@@ -245,7 +245,7 @@ func New(dir string) (*Handle, error) {
 		err = inPlaceReadLineFromPath(filename, func(data []byte, line, offset int64) error {
 			cnt++
 			if p, err := parseLine(data, line, offset); err != nil {
-				return fmt.Errorf("%s:%d: %s", err)
+				return fmt.Errorf("%s:%d: %v", data, line, err)
 			} else if p != nil {
 				// first, let's identify the cluster
 				index := ix{p.byteOffset, p.pos}


### PR DESCRIPTION
This PR adds a new `Look.NumRelations()` function that returns the number of relationships an entry has. This is useful for sorting results based on relations.